### PR TITLE
v1.1.1

### DIFF
--- a/src/VisualStudio.Templates.Files/ExceptionUnitTest.cs
+++ b/src/VisualStudio.Templates.Files/ExceptionUnitTest.cs
@@ -13,7 +13,7 @@ namespace $rootnamespace$
         {
             var exception = new $classnameundertest$();
 
-            exception.Message.Should().Be("Exception of type '$rootnamespace$.$classnameundertest$' was thrown.");
+            exception.Message.Should().Be("Exception of type '$namespaceundertest$.$classnameundertest$' was thrown.");
             exception.InnerException.Should().BeNull();
         }
 

--- a/src/VisualStudio.Templates.Files/RazorComponent.razor.cs
+++ b/src/VisualStudio.Templates.Files/RazorComponent.razor.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="$rootname$" company="$company$">
+// <copyright file="$rootname$.cs" company="$company$">
 //     Copyright (c) $company$. All rights reserved.
 // </copyright>
 //-----------------------------------------------------------------------

--- a/src/VisualStudio.Templates/CompanySelectionWizard.cs
+++ b/src/VisualStudio.Templates/CompanySelectionWizard.cs
@@ -82,6 +82,17 @@ namespace PosInformatique.VisualStudio.Templates
 
                 replacementsDictionary.Add("$classnameundertest$", classNameUnderTest);
 
+                // For unit tests of the exception, add a setting without the "Tests" namespace suffix
+                var rootnamespace = replacementsDictionary["$rootnamespace$"];
+                var namespaceundertest = rootnamespace;
+
+                if (namespaceundertest.EndsWith("Tests"))
+                {
+                    namespaceundertest = namespaceundertest.Substring(0, namespaceundertest.Length - ".Tests".Length);
+                }
+
+                replacementsDictionary.Add("$namespaceundertest$", namespaceundertest);
+
                 this.shouldAddProjectItem = true;
             }
         }


### PR DESCRIPTION
- Fix the Razor code behind file name in the header by adding a .cs at the end (fixes #4).
- Removes the ".Tests" in the default exception message in the unit tests (fixes #6).