### PR TITLE
v1.1.2

### DIFF
--- a/VisualStudio.Templates.package.proj
+++ b/VisualStudio.Templates.package.proj
@@ -11,7 +11,7 @@
     <_SolutionDir>$(MSBuildProjectDirectory)\</_SolutionDir>
 
     <_NuGetPackageFolder>$(USERPROFILE)\.nuget\packages\</_NuGetPackageFolder>
-    <_VsSDKBuildToolsFolder>$(_NuGetPackageFolder)microsoft.vssdk.buildtools\17.5.4074\tools\vssdk\</_VsSDKBuildToolsFolder>
+    <_VsSDKBuildToolsFolder>$(_NuGetPackageFolder)microsoft.vssdk.buildtools\17.12.2069\tools\vssdk\</_VsSDKBuildToolsFolder>
     <_VsixUtil>$(_VsSDKBuildToolsFolder)bin\VsixUtil.exe</_VsixUtil>
   </PropertyGroup>
 

--- a/build/azure-pipelines-release.yaml
+++ b/build/azure-pipelines-release.yaml
@@ -2,7 +2,7 @@ parameters:
 - name: Version
   displayName: The version of the Visual Studio Templates
   type: string
-  default: 1.1.0.0
+  default: 1.1.2.0
 
 trigger: none
 

--- a/src/VisualStudio.Templates/CompanySelectionWizard.cs
+++ b/src/VisualStudio.Templates/CompanySelectionWizard.cs
@@ -56,7 +56,7 @@ namespace PosInformatique.VisualStudio.Templates
 
                     if (styleCopConfiguration != null)
                     {
-                        company = styleCopConfiguration.Settings.DocumentationRules.CompanyName;
+                        company = styleCopConfiguration.Settings?.DocumentationRules?.CompanyName;
                     }
                 }
             }

--- a/src/VisualStudio.Templates/VisualStudio.Templates.csproj
+++ b/src/VisualStudio.Templates/VisualStudio.Templates.csproj
@@ -59,10 +59,10 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.5.33428.388" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.11.40262" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.5.4074">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.12.2069">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
- Fix a bug when using a C# template when the `stylecop.json` contains invalid JSON nodes (fixes #8).